### PR TITLE
Update thông tin các modul ESP8266

### DIFF
--- a/docs/00-introduction/03-esp-module.md
+++ b/docs/00-introduction/03-esp-module.md
@@ -6,29 +6,61 @@ ESP8266 cần ít nhất thêm 7 linh kiện nữa mới có thể hoạt độn
 ### Một số module ESP8266 trên thị trường
 
 #### ESP-01
+![Image of ESP-01](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=01-01.jpg)
 
 #### ESP-02
+![Image of ESP-02](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=02-01.jpg)
 
 #### ESP-03
+![Image of ESP-03](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=03-01.jpg)
 
 #### ESP-04
-
+![Image of ESP-04](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=04-01.jpg)
 #### ESP-05
-
+![Image of ESP-05](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=05-01.jpg)
 #### ESP-06
-
+![Image of ESP-06](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=06-01.jpg)
 #### ESP-07
-
+![Image of ESP-07](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=07-01.jpg)
 #### ESP-08
-
+![Image of ESP-08](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=08-01.jpg)
 #### ESP-09
-
+![Image of ESP-09](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=09-02.jpg)
 #### ESP-10
-
+![Image of ESP-10](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=10-01.jpg)
 #### ESP-11
-
+![Image of ESP-11](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=11-01.jpg)
 #### ESP-12
+![Image of ESP-12](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=12-01.jpg)
+#### ESP-12EQ
+![Image of ESP-12EQ](https://nettigo.pl/system/images/1553/original.jpg?1460632421)
+#### ESP-13
+![Image of ESP-13](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=esp-13.jpg)
+#### ESP-14
+![Image of ESP-14](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=esp8266-14_withshield.jpg)
+#### ESP-WROOM-02
+![Image of ESP-WROOM-02](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=wroom2-back.png)
+#### WT8266-S1
+![Image of WT8266-S1](http://www.esp8266.com/wiki/lib/exe/fetch.php?cache=&media=wt8266-s1-1.jpg)
+#### Bảng so sánh các thông số
 
-#### ESP-12A
-
-#### ESP-WROOM
+| Phiên bản   | Số chân   | pitch  | form factor | LEDs | Antenna       | Ant.Socket | Shielded | chiều dài mm | 
+|------------|--------|--------|-------------|------|---------------|------------|----------|---------------| 
+| ESP-01     | 8      | .1“    | 2×4 DIL     | Yes  | Etched-on PCB | No         | No       | 14.3 x 24.8   | 
+| ESP-02     | 8      | .1”    | 2×4 notch   | No?  | None          | Yes        | No       | 14.2 x 14.2   | 
+| ESP-03     | 14     | 2mm    | 2×7 notch   | No   | Ceramic       | No         | No       | 17.3 x 12.1   | 
+| ESP-04     | 14     | 2mm    | 2×4 notch   | No?  | None          | No         | No       | 14.7 x 12.1   | 
+| ESP-05     | 5      | .1“    | 1×5 SIL     | No   | None          | Yes        | No       | 14.2 x 14.2   | 
+| ESP-06     | 12+GND | misc   | 4×3 dice    | No   | None          | No         | Yes      | 16.3 x 13.1   | 
+| ESP-07     | 16     | 2mm    | 2×8 pinhole | Yes  | Ceramic       | Yes        | Yes      | 20.0 x 16.0   | 
+| ESP-08     | 14     | 2mm    | 2×7 notch   | No   | None          | No         | Yes      | 17.0 x 16.0   | 
+| ESP-08 New | 16     | 2mm    | 2×8 notch   | No   | None          | No         | Yes      | 18.0 x 16.0   | 
+| ESP-09     | 12+GND | misc   | 4×3 dice    | No   | None          | No         | No       | 10.0 x 10.0   | 
+| ESP-10     | 5      | 2mmm?  | 1×5 notch   | No   | None          | No         | No       | 14.2 x 10.0   | 
+| ESP-11     | 8      | 1.27mm | 1×8 pinhole | No?  | Ceramic       | No         | No       | 17.3 x 12.1   | 
+| ESP-12     | 16     | 2mm    | 2×8 notch   | Yes  | Etched-on PCB | No         | Yes      | 24.0 x 16.0   | 
+| ESP-12-E   | 22     | 2mm    | 2×8 notch   | Yes  | Etched-on PCB | No         | Yes      | 24.0 x 16.0   | 
+| ESP-13     | 18     | 1.5mm  | 2×9         | ?    | Etched-on PCB | No         | Yes      | ? x ?         | 
+| ESP-14     | 22     | 2mm    | 2×8 + 6     | 1    | Etched-on PCB | No         | Yes      | 24.3 x 16.2   | 
+| WROOM-02   | 18     | 1.5mm  | 2×9         | No   | Etched on PCB | No         | Yes      | 20.0 x 18.0   | 
+| WT8266-S1  | 18     | 1.5mm  | 3×6         | 1    | Etched on PCB | No         | Yes      | 15.0 x 18.6   | 


### PR DESCRIPTION
Nguồn e lấy từ
http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family, trừ em
ESP12-E hình bị xida phải gg, đã cập nhật đủ các dòng ESP + thêm bảng so sánh
